### PR TITLE
Refactor: Separate bytecode disassembler logic

### DIFF
--- a/disassembler.py
+++ b/disassembler.py
@@ -1,0 +1,23 @@
+import dis
+import io
+from contextlib import redirect_stdout
+
+def disassemble_code(code_str):
+    """
+    Compile and disassemble a Python code string.
+    
+    Args:
+        code_str (str): Valid Python code as a string
+        
+    Returns:
+        str: The disassembled bytecode
+    """
+    # Compile the code string
+    compiled_code = compile(code_str, '<string>', 'exec')
+    
+    # Capture the output of dis.dis() in a string
+    buffer = io.StringIO()
+    with redirect_stdout(buffer):
+        dis.dis(compiled_code)
+    
+    return buffer.getvalue()

--- a/index.html
+++ b/index.html
@@ -273,28 +273,9 @@ hello()"></textarea>
                 pyodide = await loadPyodide();
                 
                 // Load the disassembly function
-                pyodide.runPython(`
-import dis
-import io
-from contextlib import redirect_stdout
-
-def disassemble_code(code_str):
-    """
-    Compile and disassemble a Python code string.
-    """
-    try:
-        # Compile the code string
-        compiled_code = compile(code_str, '<string>', 'exec')
-        
-        # Capture the output of dis.dis() in a string
-        buffer = io.StringIO()
-        with redirect_stdout(buffer):
-            dis.dis(compiled_code)
-        
-        return buffer.getvalue()
-    except Exception as e:
-        return f"Error: {str(e)}"
-                `);
+                const response = await fetch('disassembler.py');
+                const disassemblerCode = await response.text();
+                await pyodide.runPythonAsync(disassemblerCode);
                 
                 pythonReady = true;
                 showStatus('Python environment loaded successfully!', 'success');

--- a/main.py
+++ b/main.py
@@ -5,26 +5,7 @@ import io
 from contextlib import redirect_stdout
 import argparse
 import importlib.util
-
-def disassemble_code(code_str):
-    """
-    Compile and disassemble a Python code string.
-    
-    Args:
-        code_str (str): Valid Python code as a string
-        
-    Returns:
-        str: The disassembled bytecode
-    """
-    # Compile the code string
-    compiled_code = compile(code_str, '<string>', 'exec')
-    
-    # Capture the output of dis.dis() in a string
-    buffer = io.StringIO()
-    with redirect_stdout(buffer):
-        dis.dis(compiled_code)
-    
-    return buffer.getvalue()
+from disassembler import disassemble_code
 
 def disassemble_function(module_name, function_name):
     """


### PR DESCRIPTION
- I moved the `disassemble_code` function from `main.py` to a new dedicated file `disassembler.py`.
- I updated `index.html` to fetch and load `disassembler.py` in Pyodide instead of using an inline Python script.
- I modified `main.py` to import `disassemble_code` from the new `disassembler.py` to maintain CLI functionality.

This change decouples the core disassembling logic from the web interface and command-line tool, improving modularity and maintainability.